### PR TITLE
Move Reference To Order Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,32 @@
             />
           </div>
 
+          <!-- Reference -->
+          <div class="mb-4">
+            <label
+              class="block text-gray-700 text-sm font-bold mb-2"
+              for="lastname"
+            >
+              Reference
+            </label>
+            <input
+            class="
+              appearance-none
+              border
+              rounded
+              w-full
+              py-2
+              px-3
+              text-gray-700
+              leading-tight
+              focus:outline-none focus:shadow-outline
+            "
+            id="reference"
+            type="text"
+            placeholder="T615026437606272"
+          />
+          </div>
+
           <!-- Pay Button -->
           <div class="flex items-center justify-between">
             <button
@@ -251,31 +277,6 @@
               id="paystackKey"
               type="text"
               placeholder="pk_test_********************"
-            />
-          </div>
-
-          <div class="mb-4">
-            <label
-              class="block text-gray-700 text-sm font-bold mb-2"
-              for="reference"
-            >
-              Reference
-            </label>
-            <input
-              class="
-                appearance-none
-                border
-                rounded
-                w-full
-                py-2
-                px-3
-                text-gray-700
-                leading-tight
-                focus:outline-none focus:shadow-outline
-              "
-              id="reference"
-              type="text"
-              placeholder="T615026437606272"
             />
           </div>
 

--- a/main.js
+++ b/main.js
@@ -34,7 +34,6 @@ function updateProjectForm(element) {
   document.getElementById('projectId').value = project.projectId;
   document.getElementById('projectName').value = project.projectName;
   document.getElementById('paystackKey').value = project.paystackKey;
-  document.getElementById('reference').value = project.reference;
   document.getElementById('verifyEndpoint').value = project.verifyEndpoint;
   document.getElementById('authToken').value = project.authToken;
 }
@@ -75,7 +74,6 @@ const addProject = (event) => {
 
   const projectName = document.getElementById('projectName').value;
   const paystackKey = document.getElementById('paystackKey').value;
-  const reference = document.getElementById('reference').value;
   const verifyEndpoint = document.getElementById('verifyEndpoint').value;
   const authToken = document.getElementById('authToken').value;
 
@@ -84,7 +82,6 @@ const addProject = (event) => {
     updateProject(projectIdHiddenInput, {
       projectName,
       paystackKey,
-      reference,
       verifyEndpoint,
       authToken,
     });
@@ -149,10 +146,10 @@ const payWithPaystack = (event) => {
   const email = document.getElementById('email').value;
   const firstname = document.getElementById('firstname').value;
   const lastname = document.getElementById('lastname').value;
+  const reference = document.getElementById('reference').value;
 
   const paystackKey = document.getElementById('paystackKey').value;
 
-  const reference = document.getElementById('reference').value;
   const verifyEndpoint = document.getElementById('verifyEndpoint').value;
   const authToken = document.getElementById('authToken').value;
 


### PR DESCRIPTION
The transaction reference happens not to be a project-wide setting. Sometimes, it can be required to be passed to every order. This PR moves the reference field from the project form to the order form so that it can be passed along with an order when necessary.